### PR TITLE
Drop install warning in __init__.py

### DIFF
--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,15 +1,8 @@
 """{{cookiecutter.short_description}}"""
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    print(f'{__name__} package is not installed!\n'
-          f'Install in editable/develop mode via (from the top of this repo):\n'
-          f'   python -m pip install -e .[develop]\n'
-          f'Or, to just get the version number use:\n'
-          f'   python setup.py --version')
+__version__ = version(__name__)
 
 __all__ = [
     '__version__',


### PR DESCRIPTION
Now that we: 
* switched to a `pyproject.toml` the install warning in `__init__.py` is out of date
* switched to a `src` layout we don't expect users to have an uninstalled version of the package on their PYTHONPATH and likely don't need to be as defensive