### PR TITLE
Update email in Code of Conduct

### DIFF
--- a/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
+++ b/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement by emailing the
-ASF APD/Tools team at [UAF-asf-apd@alaska.edu](mailto:UAF-asf-apd@alaska.edu).
+ASF APD/Tools team at [{{cookiecutter.github_email}}](mailto:{{cookiecutter.github_email}}).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
+++ b/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement by emailing the
-ASF APD/Tools team at [{{cookiecutter.github_email}}](mailto:{{cookiecutter.github_email}}).
+development team at [{{cookiecutter.github_email}}](mailto:{{cookiecutter.github_email}}).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
For the generic cookiecutter, we likely don't want the Tools Team email to be the reporting path for CoC violations. 

I've used the email we prompt for here, but we also could:
* suggest opening an issue (not private though)
* also prompt for this
* ??