### PR TITLE
Drop importlib-metadata

### DIFF
--- a/{{cookiecutter.project_name}}/environment.yml
+++ b/{{cookiecutter.project_name}}/environment.yml
@@ -18,4 +18,3 @@ dependencies:
   - pytest-cov
   # For running
   - hyp3lib>=1.6,<2
-  - importlib_metadata


### PR DESCRIPTION
We don't need [importlib-metadata](https://pypi.org/project/importlib-metadata/) as we require python >3.8. 

--- 

`Importlib_metadata` is a backport of `importlib.metadata` which was introduced in Python 3.8:
https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata