### PR TITLE
Remove entrypoints

### DIFF
--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -26,10 +26,6 @@ dependencies = [
 ]
 dynamic = ["version", "readme"]
 
-[project.scripts]
-{{ cookiecutter.__package_name }} = "{{ cookiecutter.__package_name }}.__main__:main"
-{{ cookiecutter.__process_name }} = "{{ cookiecutter.__package_name }}.process:main"
-
 [project.optional-dependencies]
 develop = [
     "flake8",

--- a/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
+++ b/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
@@ -1,8 +1,3 @@
 def test_{{cookiecutter.__package_name}}(script_runner):
-    ret = script_runner.run('{{cookiecutter.__package_name}}', '-h')
-    assert ret.success
-
-
-def test_{{cookiecutter.__process_name}}(script_runner):
-    ret = script_runner.run('{{cookiecutter.__process_name}}', '-h')
+    ret = script_runner.run('python -m {{cookiecutter.__package_name}}', '-h')
     assert ret.success


### PR DESCRIPTION
Since users won't necessarily need a CLI interface, we have removed this functionality from the cookiecutter. Fixes https://github.com/ASFHyP3/hyp3-cookiecutter/issues/10.