### PR TITLE
Fix entrypoint test

### DIFF
--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -41,6 +41,9 @@ develop = [
 Homepage = "{{ cookiecutter.public_url }}"
 Documentation = "https://hyp3-docs.asf.alaska.edu"
 
+[project.scripts]
+{{ cookiecutter.__process_name }} = "{{ cookiecutter.__package_name }}.process:main"
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -42,8 +42,6 @@ Homepage = "{{ cookiecutter.public_url }}"
 Documentation = "https://hyp3-docs.asf.alaska.edu"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q"
 testpaths = ["tests"]
 script_launch_mode = "subprocess"
 

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -41,8 +41,11 @@ develop = [
 Homepage = "{{ cookiecutter.public_url }}"
 Documentation = "https://hyp3-docs.asf.alaska.edu"
 
-[project.scripts]
-{{ cookiecutter.__process_name }} = "{{ cookiecutter.__package_name }}.process:main"
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = ["tests"]
+script_launch_mode = "subprocess"
 
 [tool.setuptools]
 include-package-data = true

--- a/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
+++ b/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
@@ -1,3 +1,3 @@
 def test_{{cookiecutter.__package_name}}(script_runner):
-    ret = script_runner.run('python -m {{cookiecutter.__package_name}}', '-h')
+    ret = script_runner.run('{{cookiecutter.__package_name}}', '-h')
     assert ret.success

--- a/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
+++ b/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
@@ -1,3 +1,3 @@
 def test_{{cookiecutter.__package_name}}(script_runner):
-    ret = script_runner.run('{{cookiecutter.__package_name}}', '-h')
+    ret = script_runner.run('python', '-m', '{{cookiecutter.__package_name}}', '-h')
     assert ret.success


### PR DESCRIPTION
After further thought, I'd like to keep at least one of the entrypoints. `script_runner` in `test_entrypoints.py` only [works with entrypoints](https://github.com/kvas-it/pytest-console-scripts#usage) so we'll need to refactor the test if we don't keep one, and I think having an entrypoint will be important for most development workflows. I was leaning towards re-introducing the science entrypoint but could be persuaded to include the HyP3 one instead.