### PR TITLE
Expose the `process_* function via the package API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Next, we'll need to create a new repository on [GitHub](https://github.com) for 
 Make sure to create your repository in the same user/organization account you set in the
 `<GITHUB_USERNAME>` field of the cookiecutter.
 
-You repository name should be the same as the directory name for the plugin you created
+Your repository name should be the same as the directory name for the plugin you created
 on your local develop machine. (e.g., `hyp3-<PROCESS_TYPE>`). For the description section,
 you can copy in the short description you created in the cookiecutter step. You can find this
 in your newly-generated, `README.md` file, or in your command line history. Next, set the 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -1,6 +1,7 @@
 """{{cookiecutter.short_description}}"""
 
 from importlib.metadata import version
+
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
 __version__ = version(__name__)

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -4,4 +4,4 @@ from importlib.metadata import version
 
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
-__version__ = version(__name__)
+__version__ = version({{cookiecutter.__package_name}})

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -1,6 +1,7 @@
 """{{cookiecutter.short_description}}"""
 
 from importlib.metadata import version
+from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
 __version__ = version(__name__)
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -5,7 +5,3 @@ from importlib.metadata import version
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
 __version__ = version(__name__)
-
-__all__ = [
-    '__version__',
-]

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -4,4 +4,4 @@ from importlib.metadata import version
 
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
-__version__ = version({{cookiecutter.__package_name}})
+__version__ = version('{{cookiecutter.__package_name}}')

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -4,7 +4,6 @@
 
 import argparse
 import logging
-from pathlib import Path
 
 from {{cookiecutter.__package_name}} import __version__
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -4,8 +4,9 @@
 
 import argparse
 import logging
+from importlib.metadata import version
 
-from {{cookiecutter.__package_name}} import __version__
+__version__ = version({{cookiecutter.__package_name}})
 
 log = logging.getLogger(__name__)
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 from importlib.metadata import version
 
-__version__ = version({{cookiecutter.__package_name}})
+__version__ = version('{{cookiecutter.__package_name}}')
 
 log = logging.getLogger(__name__)
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -5,6 +5,7 @@
 import argparse
 import logging
 from importlib.metadata import version
+from pathlib import Path
 
 __version__ = version('{{cookiecutter.__package_name}}')
 


### PR DESCRIPTION
This PR would have exposed the `process_*` function via the package API in an attempt to address https://github.com/ASFHyP3/hyp3-cookiecutter/issues/26#issuecomment-1482846083. However, after testing this by creating a new package `hyp3_aaa`, this results in the following warning:

```
$ python -m hyp3_aaa.process --version
<frozen runpy>:128: RuntimeWarning: 'hyp3_aaa.process' found in sys.modules after import of package 'hyp3_aaa', but prior to execution of 'hyp3_aaa.process'; this may result in unpredictable behaviour
process_aaa 0.1.dev0
```

Which I interpret to mean that this was the wrong way to address the issue. I'm going to open and close this PR in order to document this warning.