### PR TITLE
Drop Support for Python 3.8 and 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0]
+### Removed
+* Support for Python 3.8 and 3.9 has been dropped. The minimum version is now 3.10.
 
 ## [0.1.4]
 ### Fixed

--- a/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
@@ -16,10 +16,14 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.1
     with:
       local_package_name: {{ cookiecutter.__package_name }}
+      python_versions: >-
+        ["3.10", "3.11", "3.12"]
 
   call-version-info-workflow:
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.1
+    with:
+      python_version: "3.10"
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/{{cookiecutter.__project_name}}/environment.yml
+++ b/{{cookiecutter.__project_name}}/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.8
+  - python>=3.10
   - pip
   # For packaging, and testing
   - flake8

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "{{ cookiecutter.__package_name }}"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name="{{ cookiecutter.github_username }}", email="{{ cookiecutter.github_email }}"},
 ]
@@ -16,10 +16,9 @@ classifiers=[
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "hyp3lib>=3,<4",


### PR DESCRIPTION
Changed the minimum Python version to 3.10, and set the supported versions to 3.10, 3.11, and 3.12.