### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.2

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-create-jira-issue-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.11.2
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.2
     with:
       release_prefix: HyP3 Cookiecutter
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,4 +4,4 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.2

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.2
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/update_actions_version.yml
+++ b/.github/workflows/update_actions_version.yml
@@ -1,0 +1,42 @@
+name: Update ASFHyP3/actions version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to set all ASFHyP3/actions to'
+        required: true
+        type: string
+
+jobs:
+  update_actions_examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOOLS_BOT_PAK }}
+
+      - name: Create update branch
+        id: update
+        env:
+          ACTIONS_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          git config user.name "tools-bot"
+          git config user.email "UAF-asf-apd@alaska.edu"
+
+          export UPDATE_BRANCH=update-actions-to-${ACTIONS_VERSION}
+          git switch -c ${UPDATE_BRANCH}
+          
+          export SEARCH_PATTERN='(ASFHyP3/actions/.github/workflows/.*.yml)@v[0-9]+\.[0-9]+\.[0-9]+'
+          find -iwholename "*/workflows/*.yml" -exec sed -i -r "s|$SEARCH_PATTERN|\1@${ACTIONS_VERSION}|g" {} \; 
+          
+          git commit -am "Bump actions ASFHyP3/actions version to ${ACTIONS_VERSION}"
+          git push origin ${UPDATE_BRANCH}
+
+      - name: Open PR
+        env:
+          PR_TITLE: Update ASFHyP3/actions version to ${{ env.ACTIONS_VERSION }}
+          PR_BODY: PR created by a new `v*` tag push event
+          GH_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
+        run: |
+          gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" -l tools-bot -l bumpless -B develop

--- a/.github/workflows/update_actions_version.yml
+++ b/.github/workflows/update_actions_version.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Open PR
         env:
-          PR_TITLE: Update ASFHyP3/actions version to ${{ env.ACTIONS_VERSION }}
+          PR_TITLE: Update ASFHyP3/actions version to ${{ github.event.inputs.version }}
           PR_BODY: PR created by a new `v*` tag push event
           GH_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+### Added
+* Support for Python 3.13
+* Workflow action to keep the reusable CI/CD action up to date within the cookiecutter template
+
+### Changed
+* Now uses ruff for linting and formatting instead of flake8
+
+### Removed
+* The unused `process.main` function as we don't register it as a console script entrypoint
+
+### Fixed
+* Tests using the `script_runner` fixture will no longer raise usage warnings 
+
 ## [0.2.0]
 ### Removed
 * Support for Python 3.8 and 3.9 has been dropped. The minimum version is now 3.10.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,7 +2,7 @@
   "github_username": "username_for_github_actions",
   "github_email": "email_for@github_actions.com",
   "process_type": "RTC",
-  "short_description": "HyP3 plugin for {{cookiecutter.process_type}} processing",
+  "short_description": "HyP3 plugin for {{cookiecutter.process_type}} processing.",
   "public_url": "https://github.com/ASFHyP3/hyp3-{{cookiecutter.process_type}}",
   "copyright_year": "{% now 'utc', '%Y' %}",
   "__project_name": "hyp3-{{cookiecutter.process_type | lower}}",

--- a/{{cookiecutter.__project_name}}/.github/workflows/changelog.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/changelog.yml
@@ -14,6 +14,4 @@ on:
 jobs:
   call-changelog-check-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.7.1
-    secrets:
-      USER_TOKEN: {{'${{ secrets.GITHUB_TOKEN }}'}}
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.2

--- a/{{cookiecutter.__project_name}}/.github/workflows/labeled-pr.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/labeled-pr.yml
@@ -13,4 +13,4 @@ on:
 jobs:
   call-labeled-pr-check-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.2

--- a/{{cookiecutter.__project_name}}/.github/workflows/release-checklist-comment.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/release-checklist-comment.yml
@@ -6,11 +6,11 @@ on:
       - opened
     branches:
       - main
-  
+
 jobs:
   call-release-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.11.2
     permissions:
       pull-requests: write
     secrets:

--- a/{{cookiecutter.__project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-release-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.2
     with:
       release_prefix: {{ cookiecutter.__project_title }}
       release_branch: main

--- a/{{cookiecutter.__project_name}}/.github/workflows/static-analysis.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/static-analysis.yml
@@ -5,10 +5,10 @@ on: push
 jobs:
   call-secrets-analysis-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.2
 
   call-flake8-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.7.1
+    uses:  ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.11.2
     with:
       local_package_names: {{ cookiecutter.__package_name }}

--- a/{{cookiecutter.__project_name}}/.github/workflows/tag-version.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/tag-version.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-bump-version-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.2
     with:
       user: {{ cookiecutter.github_username }}
       email: {{ cookiecutter.github_email }}

--- a/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   call-pytest-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.11.2
     with:
       local_package_name: {{ cookiecutter.__package_name }}
       python_versions: >-
@@ -21,14 +21,12 @@ jobs:
 
   call-version-info-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.1
-    with:
-      python_version: "3.10"
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.2
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.7.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.11.2
     with:
       version_tag: {{'${{ needs.call-version-info-workflow.outputs.version_tag }}'}}
       release_branch: main

--- a/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       local_package_name: {{ cookiecutter.__package_name }}
       python_versions: >-
-        ["3.10", "3.11", "3.12"]
+        ["3.10", "3.11", "3.12", "3.13"]
 
   call-version-info-workflow:
     # Docs: https://github.com/ASFHyP3/actions

--- a/{{cookiecutter.__project_name}}/.trufflehog.txt
+++ b/{{cookiecutter.__project_name}}/.trufflehog.txt
@@ -1,1 +1,0 @@
-.*gitleaks.toml$

--- a/{{cookiecutter.__project_name}}/environment.yml
+++ b/{{cookiecutter.__project_name}}/environment.yml
@@ -6,10 +6,7 @@ dependencies:
   - python>=3.10
   - pip
   # For packaging, and testing
-  - flake8
-  - flake8-import-order
-  - flake8-blind-except
-  - flake8-builtins
+  - ruff
   - setuptools
   - setuptools_scm
   - wheel

--- a/{{cookiecutter.__project_name}}/environment.yml
+++ b/{{cookiecutter.__project_name}}/environment.yml
@@ -7,11 +7,10 @@ dependencies:
   - pip
   # For packaging, and testing
   - ruff
-  - setuptools
   - setuptools_scm
-  - wheel
   - pytest
   - pytest-console-scripts
   - pytest-cov
   # For running
   - hyp3lib>=3,<4
+  # TODO: insert conda-forge dependencies as list here

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "{{ cookiecutter.__package_name }}"
+readme = "README.md"
 requires-python = ">=3.10"
 authors = [
     {name="{{ cookiecutter.github_username }}", email="{{ cookiecutter.github_email }}"},
@@ -19,12 +20,13 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "hyp3lib>=3,<4",
-    # insert python dependencies as list here
+    # TODO: insert Python dependencies as list here
 ]
-dynamic = ["version", "readme"]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 develop = [
@@ -45,9 +47,6 @@ script_launch_mode = "subprocess"
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-
-[tool.setuptools.dynamic]
-readme = {file = ["README.md"], content-type = "text/markdown"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -28,10 +28,7 @@ dynamic = ["version", "readme"]
 
 [project.optional-dependencies]
 develop = [
-    "flake8",
-    "flake8-import-order",
-    "flake8-blind-except",
-    "flake8-builtins",
+    "ruff",
     "pytest",
     "pytest-cov",
     "pytest-console-scripts",
@@ -56,3 +53,30 @@ readme = {file = ["README.md"], content-type = "text/markdown"}
 where = ["src"]
 
 [tool.setuptools_scm]
+
+[tool.ruff]
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "single"
+
+[tool.ruff.lint]
+extend-select = [
+    "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
+    "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+lines-after-imports = 2
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = ["D100", "D103", "ANN"]

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import version
 
+
 __version__ = version(__name__)
 
 __all__ = [

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
@@ -1,32 +1,28 @@
-"""
-{{cookiecutter.process_type}} processing for HyP3
-"""
+"""{{cookiecutter.process_type}} processing for HyP3."""
+
 import logging
 from argparse import ArgumentParser
 
 from hyp3lib.aws import upload_file_to_s3
 from hyp3lib.image import create_thumbnail
 
-
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
 
-def main():
-    """
-    HyP3 entrypoint for {{cookiecutter.__package_name}}
-    """
+def main() -> None:
+    """HyP3 entrypoint for {{cookiecutter.__package_name}}."""
     parser = ArgumentParser()
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
 
     # TODO: Your arguments here
-    parser.add_argument('--greeting', default='Hello world!',
-                        help='Write this greeting to a product file')
+    parser.add_argument('--greeting', default='Hello world!', help='Write this greeting to a product file')
 
     args = parser.parse_args()
 
-    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
-                        datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO)
+    logging.basicConfig(
+        format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO
+    )
 
     product_file = {{cookiecutter.__process_name}}(
         greeting=args.greeting,

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -1,18 +1,14 @@
-"""
-{{cookiecutter.process_type}} processing
-"""
+"""{{cookiecutter.process_type}} processing."""
 
-import argparse
 import logging
 from pathlib import Path
 
-from {{cookiecutter.__package_name}} import __version__
 
 log = logging.getLogger(__name__)
 
 
 def {{cookiecutter.__process_name}}(greeting: str = 'Hello world!') -> Path:
-    """Create a greeting product
+    """Create a greeting product.
 
     Args:
         greeting: Write this greeting to a product file (Default: "Hello world!" )
@@ -21,21 +17,3 @@ def {{cookiecutter.__process_name}}(greeting: str = 'Hello world!') -> Path:
     product_file = Path('greeting.txt')
     product_file.write_text(greeting)
     return product_file
-
-
-def main():
-    """{{cookiecutter.__process_name}} entrypoint"""
-    parser = argparse.ArgumentParser(
-        prog='{{cookiecutter.__process_name}}',
-        description=__doc__,
-    )
-    parser.add_argument('--greeting', default='Hello world!',
-                        help='Write this greeting to a product file')
-    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
-    args = parser.parse_args()
-
-    {{cookiecutter.__process_name}}(**args.__dict__)
-
-
-if __name__ == "__main__":
-    main()

--- a/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
+++ b/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
@@ -1,3 +1,3 @@
 def test_{{cookiecutter.__package_name}}(script_runner):
-    ret = script_runner.run('python', '-m', '{{cookiecutter.__package_name}}', '-h')
+    ret = script_runner.run(['python', '-m', '{{cookiecutter.__package_name}}', '-h'])
     assert ret.success


### PR DESCRIPTION
I demonstrated the cookie cutter in the NISAR Early Adopters workshop this morning, and some things were a little out of date, particularly the reusable actions versions.

Other than some tweaks to the generated Python package, as suggested in #56, the major thing this PR adds is a workflow dispatch trigger so the ASFHyP3/action can be updated inside the cookie-cutter template and at the top level. This is necessary because Dependabot only looks at the repository root for GitHub Actions, and you can't specify multiple directories. Technically this deprecates Dependabot for this repository but I don't see a harm in keeping it. Otherwise, we can remove the `.github/dependabot.yml` file.

I've tested that the action works by triggering it to downgrade the actions to `v0.11.1`, which you can:
* see it run in: https://github.com/ASFHyP3/hyp3-cookiecutter/actions/runs/11284295265/job/31385244268
* see the resulting PR: #65 

Most other changes are described in the changelog or formatting changes to satisfy ruff for the newly generated plugin.