### PR TITLE
Minor updates/tweaks to cookiecutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0]
+### Changed
+- In the generated project, ruff and mypy dependencies are now statically pinned and kept up to date with dependabot to prevent updates introducing unexpected static analysis failures  
+
+### Fixed
+- Added mypy to the generated Python package's optional `develop` dependencies
+- Updates the generated `CHANGELOG.md` to better match the general styles used in HyP3 repositories 
+- Ensured the generated Python package passes ruff, mypy, and pytest checks
+
+### Removed
+- Removed the broken browse image generation and upload example code
+- Removed the generated Code of Conduct file to instead prefer a GitHub organization level one 
+
 ## [0.3.3]
 ### Changed
 - Upgrade to `ASFHyP3/actions` v0.15.0 in cookiecutter workflows.

--- a/{{cookiecutter.__project_name}}/CHANGELOG.md
+++ b/{{cookiecutter.__project_name}}/CHANGELOG.md
@@ -6,5 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0]({{cookiecutter.public_url}}/compare/v0.0.0...v0.1.0) -- unreleased
+## [0.1.0]
 
+### Added
+- {{ cookiecutter.project_name }} plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)

--- a/{{cookiecutter.__project_name}}/pyproject.toml
+++ b/{{cookiecutter.__project_name}}/pyproject.toml
@@ -30,10 +30,11 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 develop = [
+    "mypy",
     "ruff",
     "pytest",
-    "pytest-cov",
     "pytest-console-scripts",
+    "pytest-cov",
 ]
 
 [project.urls]

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
@@ -4,7 +4,6 @@ import logging
 from argparse import ArgumentParser
 
 from hyp3lib.aws import upload_file_to_s3
-from hyp3lib.image import create_thumbnail
 
 from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
 
@@ -30,11 +29,6 @@ def main() -> None:
 
     if args.bucket:
         upload_file_to_s3(product_file, args.bucket, args.bucket_prefix)
-        browse_images = product_file.with_suffix('.png')
-        for browse in browse_images:
-            thumbnail = create_thumbnail(browse)
-            upload_file_to_s3(browse, args.bucket, args.bucket_prefix)
-            upload_file_to_s3(thumbnail, args.bucket, args.bucket_prefix)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a collection of minor updates after using the cookiecutter to create a new HyP3 plugin.

This:
* Updates the generated changelog to better match our current style
* Adds mypy to the dev dependencies
* alphabatizes the dev dependencies
* removed browse image generation example because it doesn't make sense -- the generated plugin creates and uploads a text file and the browse lines of code are not functional (or logical). Also, mypy chokes on it.
* ensure ruff, pytest, and mypy all pass with the generated plugin

I also updated this repositories CHANGELOG.md to match this PR and everything in develop pending release:
https://github.com/ASFHyP3/hyp3-cookiecutter/compare/main...cookiecutter-cleanup