### PR TITLE
project fails to render due typo in project variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.4.1]
+### Fixed
+- Fixed project name variable error which prevented the cookiecutter from rendering.
+
 ## [0.4.0]
 ### Changed
 - In the generated project, ruff and mypy dependencies are now statically pinned and kept up to date with dependabot to prevent updates introducing unexpected static analysis failures  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ generate a new HyP3 Plugin.
 
 ### 1. Create the plugin with Cookiecutter
 
-To create a new plugin, you'll first need to run the cookicutter.
+To create a new plugin, you'll first need to run the cookiecutter.
 From a terminal on your local development machine, navigate to where you'd like 
 to create the local copy of the plugin's repository. Then run cookiecutter and 
 follow the prompts:
@@ -197,5 +197,3 @@ for a step-by-step guide.
 
 ### GITHUB_PAK Permissions
 ![GITHUB_PAK Permissions screenshot](assets/PAK_permissions.png)
-
-

--- a/{{cookiecutter.__project_name}}/CHANGELOG.md
+++ b/{{cookiecutter.__project_name}}/CHANGELOG.md
@@ -9,4 +9,4 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.0]
 
 ### Added
-- {{ cookiecutter.project_name }} plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)
+- {{ cookiecutter.__project_name }} plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)


### PR DESCRIPTION
I tried to use the current project and got a "'collections.OrderedDict object' has no attribute 'project_name'". The variable has now the proper name.