### PR TITLE
Better handle GitHub Actions token

### DIFF
--- a/.github/workflows/render-cookiecutter.yml
+++ b/.github/workflows/render-cookiecutter.yml
@@ -22,5 +22,5 @@ jobs:
         cookiecutterValues: '{
             "github_username": "foo-bar",
             "github_email": "foo@bar.com",
-            "process_type": "foo-bar",
+            "process_type": "foo-bar"
           }'

--- a/.github/workflows/render-cookiecutter.yml
+++ b/.github/workflows/render-cookiecutter.yml
@@ -1,0 +1,28 @@
+name: Render Cookiecutter
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.2.2
+      with:
+        path: hyp3-cookiecutter
+
+    - name: Render Cookiecutter
+      uses: andrewthetechie/gha-cookiecutter@v1.3.2
+      with:
+        template: ./hyp3-cookiecutter
+        cookiecutterValues: '{
+            "github_username": "foobar",
+            "github_email": "foo@bar.com",
+            "process_type": "foo-bar",
+            "short_description": "HyP3 plugin for foo-bar processing.",
+            "public_url": "https://github.com/ASFHyP3/hyp3-foo-bar",
+            "copyright_year": "2025",
+          }'

--- a/.github/workflows/render-cookiecutter.yml
+++ b/.github/workflows/render-cookiecutter.yml
@@ -18,11 +18,9 @@ jobs:
       uses: andrewthetechie/gha-cookiecutter@v1.3.2
       with:
         template: ./hyp3-cookiecutter
+        # Any values not filled in will be set to template's default
         cookiecutterValues: '{
-            "github_username": "foobar",
+            "github_username": "foo-bar",
             "github_email": "foo@bar.com",
             "process_type": "foo-bar",
-            "short_description": "HyP3 plugin for foo-bar processing.",
-            "public_url": "https://github.com/ASFHyP3/hyp3-foo-bar",
-            "copyright_year": "2025",
           }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.4.1]
+## [0.5.0]
+### Added
+- Added a CLI option to specify the name of a user GitHub Token in the rendered plugin for the GitHub Actions workflows that require it.  
+- A GitHub Actions workflow that will ensure hyp3-cookiecutter renders.
 ### Fixed
 - Fixed project name variable error which prevented the cookiecutter from rendering.
 

--- a/README.md
+++ b/README.md
@@ -7,24 +7,43 @@ generate a new HyP3 Plugin.
 
 ### 1. Create the plugin with Cookiecutter
 
-To create a new plugin, you'll first need to run the cookiecutter.
-From a terminal on your local development machine, navigate to where you'd like 
-to create the local copy of the plugin's repository. Then run cookiecutter and 
-follow the prompts:
+To create a new plugin, you'll first need to run [`cookiecutter`](https://cookiecutter.readthedocs.io/en/stable/), which you can install with [`conda`/`mamba`](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
+(we recommend [MiniForge](https://conda-forge.org/download/)):
 
 ```bash
-python3 -m pip install cookiecutter
-cookiecutter https://github.com/ASFHyP3/hyp3-cookiecutter.git
+mamba install cookiecutter
 ```
 
-Now, you should have a `hyp3-<process>` directory which contains a minimal HyP3
-plugin.
+ or [`pip`](https://packaging.python.org/en/latest/tutorials/installing-packages/#use-pip-for-installing):
+
+```bash
+python -m pip install cookiecutter
+```
+
+Then, from a terminal on your local development machine, navigate to where you'd like
+to create the local copy of your new plugin's repository and run cookiecutter, following the prompts.
+
+For example, this may look like:
+
+```
+cookiecutter https://github.com/ASFHyP3/hyp3-cookiecutter.git
+  [1/7] github_username (username_for_github_actions): foo
+  [2/7] github_email (email_for@github_actions.com): foo@bar.com
+  [3/7] github_actions_token (FOO_PAK):
+  [4/7] process_type (RTC): foo-bar
+  [5/7] short_description (HyP3 plugin for foo-bar processing.):
+  [6/7] public_url (https://github.com/ASFHyP3/hyp3-foo-bar):
+  [7/7] copyright_year (2025):
+```
+
+> [!TIP]
+> The `github_*` prompts facilitate the CI/CD pipelines included in the cookiecutter. These can be for yourself, or a shared team "bot" user, and we'll set up a Personal Access Token in [Section 6](#6-create-a-personal-access-key-for-github-actions).
+
+Now, you should have a `hyp3-<process_type>` (`hyp3-foo-bar` in the example above) directory which contains a minimal HyP3 plugin.
 
 ### 2. Create a repository on GitHub
 
 Next, we'll need to create a new repository on [GitHub](https://github.com) for your plugin.
-Make sure to create your repository in the same user/organization account you set in the
-`<GITHUB_USERNAME>` field of the cookiecutter.
 
 Your repository name should be the same as the directory name for the plugin you created
 on your local develop machine. (e.g., `hyp3-<PROCESS_TYPE>`). For the description section,
@@ -136,8 +155,8 @@ article
 ### 6. Create a personal access key for GitHub Actions
 
 Some of the GitHub actions (`release.yml` and `tag-version.yml`) need extra permissions to work
-properly. These actions will attempt to use the `GITHUB_PAK` secret to assume a user profile
-with the needed permissions, so we'll need to create the permissions/secret.
+properly and will attempt to assume those permission via a repository secret named `<github_actions_token>`.
+So, if it doesn't already exist, we will need to  create the token.
 
 1. In your user/organization settings:
     * Click on Developer Settings
@@ -145,7 +164,7 @@ with the needed permissions, so we'll need to create the permissions/secret.
     * Click Tokens (classic)
     * Click Generate new token
     * Click Generate new token (classic)
-    * In the note section give the token a name (e.g., `GITHUB_PAK`)
+    * In the note section give the token a name (e.g., `<GH_ACCOUNT_NAME>_PAK`)
     * Check the boxes for:
         * repo
         * workflow
@@ -158,7 +177,7 @@ with the needed permissions, so we'll need to create the permissions/secret.
     * Click on Secrets and variables
     * Click on Actions
     * Click on New repository Secret
-    * Name your secret `GITHUB_PAK`
+    * Name your secret `<GH_ACCOUNT_NAME>_PAK`
     * Paste in the access token you save from the last step
     * Click Add secret
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,12 +1,14 @@
 {
   "github_username": "username_for_github_actions",
   "github_email": "email_for@github_actions.com",
+  "github_actions_token": "{{ cookiecutter.github_username | upper | replace('-', '_') + '_PAK' }}",
+  "__user_github_token": "{{ '${{ secrets.' + cookiecutter.github_actions_token  + ' }}' }}",
   "process_type": "RTC",
-  "short_description": "HyP3 plugin for {{cookiecutter.process_type}} processing.",
-  "public_url": "https://github.com/ASFHyP3/hyp3-{{cookiecutter.process_type}}",
+  "short_description": "HyP3 plugin for {{ cookiecutter.process_type }} processing.",
+  "public_url": "https://github.com/ASFHyP3/hyp3-{{ cookiecutter.process_type }}",
   "copyright_year": "{% now 'utc', '%Y' %}",
-  "__project_name": "hyp3-{{cookiecutter.process_type | lower}}",
-  "__project_title": "HyP3 {{cookiecutter.process_type}}",
-  "__package_name": "hyp3_{{cookiecutter.process_type | lower | replace('-', '_')}}",
-  "__process_name": "process_{{cookiecutter.process_type | lower | replace('-', '_')}}"
+  "__project_name": "hyp3-{{ cookiecutter.process_type | lower }}",
+  "__project_title": "HyP3 {{ cookiecutter.process_type }}",
+  "__package_name": "hyp3_{{ cookiecutter.process_type | lower | replace('-', '_') }}",
+  "__process_name": "process_{{ cookiecutter.process_type | lower | replace('-', '_') }}"
 }

--- a/{{cookiecutter.__project_name}}/.github/workflows/release-checklist-comment.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/release-checklist-comment.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       pull-requests: write
     secrets:
-      USER_TOKEN: {{'${{ secrets.GITHUB_TOKEN }}'}}
+      USER_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}

--- a/{{cookiecutter.__project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
       develop_branch: develop
       sync_pr_label: actions-bot
     secrets:
-      USER_TOKEN: {{'${{ secrets.TOOLS_BOT_PAK }}'}}
+      USER_TOKEN: {{ cookiecutter.__user_github_token }}

--- a/{{cookiecutter.__project_name}}/.github/workflows/tag-version.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/tag-version.yml
@@ -13,4 +13,4 @@ jobs:
       user: {{ cookiecutter.github_username }}
       email: {{ cookiecutter.github_email }}
     secrets:
-      USER_TOKEN: {{'${{ secrets.TOOLS_BOT_PAK }}'}}
+      USER_TOKEN: {{ cookiecutter.__user_github_token }}

--- a/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/test-and-build.yml
@@ -28,9 +28,9 @@ jobs:
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.17.1
     with:
-      version_tag: {{'${{ needs.call-version-info-workflow.outputs.version_tag }}'}}
+      version_tag: {{ '${{ needs.call-version-info-workflow.outputs.version_tag }}' }}
       release_branch: main
       develop_branch: develop
       user: {{ cookiecutter.github_username }}
     secrets:
-      USER_TOKEN: {{'${{ secrets.GITHUB_TOKEN }}'}}
+      USER_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}

--- a/{{cookiecutter.__project_name}}/Dockerfile
+++ b/{{cookiecutter.__project_name}}/Dockerfile
@@ -2,13 +2,13 @@ FROM condaforge/mambaforge:latest
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md
-LABEL org.opencontainers.image.title="{{cookiecutter.__project_title}}"
-LABEL org.opencontainers.image.description="{{cookiecutter.short_description}}"
+LABEL org.opencontainers.image.title="{{ cookiecutter.__project_title}} "
+LABEL org.opencontainers.image.description="{{ cookiecutter.short_description }}"
 LABEL org.opencontainers.image.vendor="Alaska Satellite Facility"
-LABEL org.opencontainers.image.authors="{{cookiecutter.github_username}} <{{cookiecutter.github_email}}>"
+LABEL org.opencontainers.image.authors="{{ cookiecutter.github_username }} <{{ cookiecutter.github_email }}>"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
-LABEL org.opencontainers.image.url="{{cookiecutter.public_url}}"
-LABEL org.opencontainers.image.source="{{cookiecutter.public_url}}"
+LABEL org.opencontainers.image.url="{{ cookiecutter.public_url }}"
+LABEL org.opencontainers.image.source="{{ cookiecutter.public_url }}"
 LABEL org.opencontainers.image.documentation="https://hyp3-docs.asf.alaska.edu"
 
 # Dynamic lables to define at build time via `docker build --label`
@@ -36,13 +36,13 @@ USER ${CONDA_UID}
 SHELL ["/bin/bash", "-l", "-c"]
 WORKDIR /home/conda/
 
-COPY --chown=${CONDA_UID}:${CONDA_GID} . /{{cookiecutter.__project_name}}/
+COPY --chown=${CONDA_UID}:${CONDA_GID} . /{{ cookiecutter.__project_name }}/
 
-RUN mamba env create -f /{{cookiecutter.__project_name}}/environment.yml && \
+RUN mamba env create -f /{{ cookiecutter.__project_name }}/environment.yml && \
     conda clean -afy && \
-    conda activate {{cookiecutter.__project_name}} && \
-    sed -i 's/conda activate base/conda activate {{cookiecutter.__project_name}}/g' /home/conda/.profile && \
-    python -m pip install --no-cache-dir /{{cookiecutter.__project_name}}
+    conda activate {{ cookiecutter.__project_name }} && \
+    sed -i 's/conda activate base/conda activate {{ cookiecutter.__project_name }}/g' /home/conda/.profile && \
+    python -m pip install --no-cache-dir /{{ cookiecutter.__project_name }}
 
-ENTRYPOINT ["/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/etc/entrypoint.sh"]
+ENTRYPOINT ["/{{ cookiecutter.__project_name }}/src/{{ cookiecutter.__package_name }}/etc/entrypoint.sh"]
 CMD ["-h"]

--- a/{{cookiecutter.__project_name}}/LICENSE
+++ b/{{cookiecutter.__project_name}}/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) {{cookiecutter.copyright_year}}, Alaska Satellite Facility
+Copyright (c) {{ cookiecutter.copyright_year }}, Alaska Satellite Facility
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/{{cookiecutter.__project_name}}/README.md
+++ b/{{cookiecutter.__project_name}}/README.md
@@ -1,3 +1,3 @@
-# {{cookiecutter.__project_title}}
+# {{ cookiecutter.__project_title }}
 
-{{cookiecutter.short_description}}
+{{ cookiecutter.short_description }}

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__init__.py
@@ -1,4 +1,4 @@
-"""{{cookiecutter.short_description}}"""
+"""{{ cookiecutter.short_description }}"""
 
 from importlib.metadata import version
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/__main__.py
@@ -1,15 +1,15 @@
-"""{{cookiecutter.process_type}} processing for HyP3."""
+"""{{ cookiecutter.process_type }} processing for HyP3."""
 
 import logging
 from argparse import ArgumentParser
 
 from hyp3lib.aws import upload_file_to_s3
 
-from {{cookiecutter.__package_name}}.process import {{cookiecutter.__process_name}}
+from {{ cookiecutter.__package_name }}.process import {{ cookiecutter.__process_name }}
 
 
 def main() -> None:
-    """HyP3 entrypoint for {{cookiecutter.__package_name}}."""
+    """HyP3 entrypoint for {{ cookiecutter.__package_name }}."""
     parser = ArgumentParser()
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
@@ -23,7 +23,7 @@ def main() -> None:
         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO
     )
 
-    product_file = {{cookiecutter.__process_name}}(
+    product_file = {{ cookiecutter.__process_name }}(
         greeting=args.greeting,
     )
 

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/etc/entrypoint.sh
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/etc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash --login
 set -e
-conda activate {{cookiecutter.__project_name}}
-exec python -um {{cookiecutter.__package_name}} "$@"
+conda activate {{ cookiecutter.__project_name }}
+exec python -um {{ cookiecutter.__package_name }} "$@"

--- a/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
+++ b/{{cookiecutter.__project_name}}/src/{{cookiecutter.__package_name}}/process.py
@@ -1,4 +1,4 @@
-"""{{cookiecutter.process_type}} processing."""
+"""{{ cookiecutter.process_type }} processing."""
 
 import logging
 from pathlib import Path
@@ -7,7 +7,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
-def {{cookiecutter.__process_name}}(greeting: str = 'Hello world!') -> Path:
+def {{ cookiecutter.__process_name }}(greeting: str = 'Hello world!') -> Path:
     """Create a greeting product.
 
     Args:

--- a/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
+++ b/{{cookiecutter.__project_name}}/tests/test_entrypoints.py
@@ -1,3 +1,3 @@
-def test_{{cookiecutter.__package_name}}(script_runner):
-    ret = script_runner.run(['python', '-m', '{{cookiecutter.__package_name}}', '-h'])
+def test_{{ cookiecutter.__package_name }}(script_runner):
+    ret = script_runner.run(['python', '-m', '{{ cookiecutter.__package_name }}', '-h'])
     assert ret.success


### PR DESCRIPTION
When this cookiecutter renders a new plugin, the name used for the Personal Access Token and used GitHub Actions workflows, was `TOOLS_BOT_PAK` where a user token is required, and `GITHUB_TOKEN` where the special GitHub token was sufficient. 

However, as raised in #96, this caused some confusion as:
1.  `TOOLS_BOT_PAK` is an ASF Tools team-specific name that has no meaning broadly
2. It wasn't clear if and where a user token is required. 

This PR:
* provides a CLI option to set the token name, with a reasonable default based on the GitHub username provided
* updates the README to attempt to be more clear
* adjusts some whitespace to follow jinja2 template best practices
* adds a GitHub action to ensure the template at least renders

---

Note: Coming back to this README after a long while, it could use a bigger restructure/re-write. Once we settle on where HyP3 developer docs should live, I'll start in on that.