### PR TITLE
Split test and build workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.5.2]
+
+### Changed
+- The `test-and-build.yml` workflow has been split into a `test.yml` workflow and a `build.yml` workflow.
+
+### Fixed
+- Pytest and the Docker build will be run on pushes to `develop` now.
+
 ## [0.5.1]
 
 ### Added

--- a/{{cookiecutter.__project_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/build.yml
@@ -1,9 +1,9 @@
-name: Test and build
+name: Build
 
 on:
   push:
     branches:
-      - main
+      - develop
     tags:
       - 'v*'
   pull_request:
@@ -12,16 +12,6 @@ on:
       - develop
 
 jobs:
-  call-pytest-workflow:
-    # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.20.0
-    permissions:
-      contents: read
-    with:
-      local_package_name: {{ cookiecutter.__package_name }}
-      python_versions: >-
-        ["3.10", "3.11", "3.12", "3.13"]
-
   call-version-info-workflow:
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.20.0

--- a/{{cookiecutter.__project_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.__project_name}}/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  call-pytest-workflow:
+    # Docs: https://github.com/ASFHyP3/actions
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.20.0
+    permissions:
+      contents: read
+    with:
+      local_package_name: {{ cookiecutter.__package_name }}
+      python_versions: >-
+        ["3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
With the upgrade to actions v0.20.0,  the Docker containers are built and tagged based on the version number reported by the plugin instead of branches. This separates out the test workflow, which we want to be branch-based, from the build workflow, which we want to trigger on tags.

Also, `test-and-build.yml` had a bug such that it didn't trigger on pushes to `develop`, which has been fixed in both `test.yml` and `build.yml`.

Note:We've done this for some of our plugins already:
https://github.com/search?q=org%3AASFHyP3+path%3A.github%2Fworkflows%2Fbuild.yml&type=code

But we still need to distribute that change out to the rest:
https://github.com/search?q=org%3AASFHyP3+path%3A.github%2Fworkflows%2Ftest-and-build.yml+-is%3Aarchived+&type=code